### PR TITLE
add log.error and force failure when unable to create symlink

### DIFF
--- a/tasks/symlink.js
+++ b/tasks/symlink.js
@@ -46,6 +46,8 @@ module.exports = function(grunt) {
         grunt.verbose.ok();
       } catch(e) {
         grunt.verbose.error();
+        grunt.log.error(e);
+        grunt.fail.warn('Failed to create symlink: ' + '(' + mode + ') ' + destpath + ' -> ' + srcpath + '.');
       }
       linkCount++;
     });


### PR DESCRIPTION
Running grunt-contrib-symlink fails on Windows if not running the cli as administrator. The task was showing as successfully completed, only reflecting error state in verbose mode. 

PR adds error logging and failing out (as an application relying on these symlinks would not work if they weren't created).
