### PR TITLE
add backreference/regex feature

### DIFF
--- a/tasks/symlink.js
+++ b/tasks/symlink.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
     this.files.forEach(function(f) {
       var srcpath = f.src[0];
       var destpath = f.dest;
-      if (f.regex) {
+      if (f.regex && f.backreference) {
         destpath = f.src[0].replace(f.regex, f.backreference);
       }
       if (!grunt.file.exists(srcpath)) {


### PR DESCRIPTION
Using regex and backreferencing allows for incredibly flexible symlinking scenarios a la:

``` javascript
options: {
    overwrite: true
},
expanded: {
    files: [{
        expand: true,
        overwrite: true,
        flatten: false,
        cwd: 'public/components',
        src: ['*/*/*.dust'],
        regex: /(public\/components)(\/.+)(\/templates)(\/.+dust)/g,
        backreference: 'public/templates/components$2$4'
    }, {
        expand: true,
        overwrite: true,
        flatten: false,
        cwd: 'public/components/',
        src: ['*/*/*/*/*.properties'],
        regex: /(public\/components)(\/.+)(\/locales)(\/[A-Z]{2}\/[a-z]{2})(\/.+properties)/g,
        backreference: 'locales$4/components$2$5'
    }]
}
```

Above configuration will symlink files:

```
public/templates/foo/[bar.dust, bing.dust] => 
public/components/foo/templates/[bar.dust, bing.dust]
```

and

```
locales/[DE/de, US/en]/components/[bar.properties, bing.properties] => 
public/components/foo/locales/[DE/de, US/en]/[bar.properties, bing.properties]
```
