### PR TITLE
Add boolean option "force" to ignore errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,13 @@ module.exports = function(grunt) {
 
     // Configuration to be run (and then tested).
     symlink: {
+      forceIgnoresErrors: {
+        options: {
+          force: true,
+        },
+        src: 'test',
+        dest: 'test2//',
+      },
       explicit: {
         src: 'test/fixtures/baz.txt',
         dest: 'tmp/baz.txt'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Task targets, files and options may be specified according to the grunt [Configu
 
 Note that the symlink mode (file, dir) is determined automatically based on the src file type.
 
+### Options
+
+There are the following task-wide options available:
+
+
+#### force
+
+Type: `Boolean`  
+Default: `false`
+
+Set `force` to `true` to report errors but not fail the task, if the link creation is not so important for the task output.
 
 ### Usage Examples
 
@@ -99,4 +110,4 @@ the task will not work.
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Sat Feb 01 2014 23:58:37.*
+*This file was generated on Thu Feb 05 2015 20:14:01.*

--- a/docs/symlink-options.md
+++ b/docs/symlink-options.md
@@ -1,0 +1,11 @@
+# Options
+
+There are the following task-wide options available:
+
+
+## force
+
+Type: `Boolean`  
+Default: `false`
+
+Set `force` to `true` to report errors but not fail the task, if the link creation is not so important for the task output.

--- a/tasks/symlink.js
+++ b/tasks/symlink.js
@@ -19,8 +19,12 @@ module.exports = function(grunt) {
 
     // default options
     var options = this.options({
+      force: false,
       overwrite: false
     });
+
+    // Report errors but don't fail the task
+    var force = options.force;
 
     // overwrite options from CLI
     options.overwrite = grunt.option('overwrite') || options.overwrite;
@@ -56,12 +60,13 @@ module.exports = function(grunt) {
           fs.symlinkSync(srcpath, destpath, mode);
         }
         grunt.verbose.ok();
+        linkCount++;
       } catch(e) {
         grunt.verbose.error();
         grunt.log.error(e);
-        grunt.fail.warn('Failed to create symlink: ' + '(' + mode + ') ' + destpath + ' -> ' + srcpath + '.');
+        var warn = force ? grunt.log.warn : grunt.fail.warn;
+        warn('Failed to create symlink: ' + '(' + mode + ') ' + destpath + ' -> ' + srcpath + '.');
       }
-      linkCount++;
     });
     grunt.log.ok('Created ' + linkCount + ' symbolic links.');
   });


### PR DESCRIPTION
This options makes the Grunt build ignore errors of this task only.  Similar to the `force` option of the [jshint task](https://github.com/gruntjs/grunt-contrib-jshint).

The link creation may not be so important for the task output.  If the links are created for the developer convenience, the errors may be ignored on the production machine.