### PR TITLE
Change 'Destination already exists' warning to verbose only and "ok"

### DIFF
--- a/tasks/symlink.js
+++ b/tasks/symlink.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
         return;
       } else if (grunt.file.exists(destpath)) {
         if (!options.overwrite) {
-          grunt.log.warn('Destination ' + destpath + ' already exists.');
+          grunt.verbose.ok('Skipping ' + destpath + '. Destination already exists.');
           return;
         }
         grunt.file.delete(destpath, {force: options.force});


### PR DESCRIPTION
Considering overwriting files or not is controlled by user settings, displaying warnings about expected behavior is just confusing. The list could also be quite long.

If you want to notify users about skipped files, how about showing a skipped files count in `grunt.log.ok('Created ' + linkCount + ' symbolic links.')`